### PR TITLE
fix: ignore ja-no-mixed-period when sentence ends with emoji

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -15,7 +15,8 @@
         "allow": ["か"]
       },
       "ja-no-mixed-period": {
-        "allowPeriodMarks": [":"]
+        "allowPeriodMarks": [":"],
+        "allowEmojiAtEnd": true
       },
       "sentence-length": false
     },


### PR DESCRIPTION
## Summary

Closes #4

`ja-no-mixed-period` rule に `allowEmojiAtEnd: true` を追加し、文末に絵文字が使用されている場合に警告が発生しないようにします。

## Changes

- `.textlintrc.json`: `ja-no-mixed-period` に `allowEmojiAtEnd: true` を追加